### PR TITLE
Add disk caching

### DIFF
--- a/contacts.py
+++ b/contacts.py
@@ -3,7 +3,6 @@
 from twisted.logger import Logger
 import os
 import json
-import rtree
 import copy
 import math
 import random
@@ -237,8 +236,9 @@ class FSBackedThreeLevelDict:
         return self.item_count
 
     def retrieve_json_from_file_path(self, file_path):
-        if file_path in self.disk_cache:
-            return self.disk_cache[file_path]
+        res = self.disk_cache.get(file_path) # Don't use the "in disk_cache" structure as wouldnt be thread safe
+        if res:
+            return res
         else:
             (key, floating_seconds, serial_number) = FSBackedThreeLevelDict._get_parts_from_file_path(file_path)
             keep = (current_time() - floating_seconds) < self.disk_cache_retention_time


### PR DESCRIPTION
Adds a simple disk cache - holds data for 2 hours, since most data points reported to the server are going to be pulled down in the next 2 hours.

It doesn't seem to help as much as I hoped - BUT I'm testing on a SSD so its comparing fast memory to slow memory, not comparing fast memory to disk. 